### PR TITLE
fix: JavaScript code rendering as plain text

### DIFF
--- a/index.html
+++ b/index.html
@@ -401,6 +401,8 @@
     <script src="js/main.js"></script>
     <script src="js/gallery.js"></script>
     <script src="js/forms.js"></script>
+    
+    <script>
         // Initialize AOS (Animate On Scroll)
         AOS.init({
             duration: 800,
@@ -674,6 +676,7 @@
             img.style.transition = 'opacity 0.5s ease';
             imageObserver.observe(img);
         });
+    </script>
 
 </body>
 </html>


### PR DESCRIPTION
Fixes ##3

This PR resolves the issue where JavaScript code was being rendered as plain text at the bottom of the page on both desktop and mobile.

## Changes
- Added missing opening `<script>` tag at line 405
- Added missing closing `</script>` tag at line 679
- All JavaScript functionality now properly executes instead of being displayed

## Testing
The fix ensures all website features work correctly:
- AOS animations
- Mobile menu toggle
- Smooth scrolling
- Gallery swiper
- Contact form
- Button animations
- Counter animations
- Scroll-to-top functionality

Generated with [Claude Code](https://claude.ai/code)